### PR TITLE
THRIFT-3736 C++ library build fails if OpenSSL does not surrpot SSLv3

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -141,10 +141,12 @@ SSLContext::SSLContext(const SSLProtocol& protocol) {
   {
     ctx_ = SSL_CTX_new(SSLv23_method());
   }
+#ifndef OPENSSL_NO_SSL3
   else if(protocol == SSLv3)
   {
     ctx_ = SSL_CTX_new(SSLv3_method());
   }
+#endif
   else if(protocol == TLSv1_0)
   {
     ctx_ = SSL_CTX_new(TLSv1_method());


### PR DESCRIPTION
Cherry-picking the fix from upstream (for compiling on linux)